### PR TITLE
Fix chromedeiver install fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ coverage
 .tags
 /.vagrant
 /vendor/ruby
+.webdrivers

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby:2.6.5
 RUN echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list \
  && curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
  && apt-get update -qq \
- && apt-get install -y --no-install-recommends build-essential libpq-dev nodejs google-chrome-stable chromium-driver \
+ && apt-get install -y --no-install-recommends build-essential libpq-dev nodejs google-chrome-stable \
  && apt-get clean \
  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 RUN mkdir /myapp

--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ group :development, :test, :mysql do
   gem "rspec-rails", '4.0.0.beta3' # 4/26/2019: LOCKED DOWN
   gem "selenium-webdriver"
   gem "test-unit"
+  gem "webdrivers", '~> 4.0'
 end
 
 group :mysql do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -334,6 +334,10 @@ GEM
     unicorn (5.5.1)
       kgio (~> 2.6)
       raindrops (~> 0.7)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -386,6 +390,7 @@ DEPENDENCIES
   turbolinks
   uglifier
   unicorn
+  webdrivers (~> 4.0)
 
 RUBY VERSION
    ruby 2.6.5p114

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,5 +5,7 @@ services:
     command: bash -c "rm -f tmp/pids/server.pid && bundle exec rails s -p 3000 -b '0.0.0.0'"
     volumes:
       - .:/myapp
+    environment:
+      - "WD_INSTALL_DIR=/myapp/.webdrivers"
     ports:
       - "3000:3000"


### PR DESCRIPTION
`docker-compose build` fails like below due to missing chromedriver. so I install it via webdrivers gem.

```
docker-compose build
Building web
Step 1/8 : FROM ruby:2.5.5
2.5.5: Pulling from library/ruby
4ae16bd47783: Pull complete
bbab4ec87ac4: Pull complete
2ea1f7804402: Pull complete
96465440c208: Pull complete
6ac892e64b94: Pull complete
1f85508cf3dd: Pull complete
3bd8a488df27: Pull complete
ca1fc8b759f6: Pull complete
Digest: sha256:219b0f233f8214793ccc8cdc787224dc6cfb728e98af9ea2c991f23bf1aee1ab
Status: Downloaded newer image for ruby:2.5.5
 ---> e93b746e985b
Step 2/8 : RUN echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list  && curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -  && apt-get update -qq  && apt-get install -y --no-install-recommends build-essential libpq-dev nodejs google-chrome-stable chromedriver  && apt-get clean  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*
 ---> Running in 76518fe2a7dd
Warning: apt-key output should not be parsed (stdout is not a terminal)
OK
Reading package lists...
Building dependency tree...
Reading state information...
Package chromedriver is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

E: Package 'chromedriver' has no installation candidate
ERROR: Service 'web' failed to build: The command '/bin/sh -c echo 'deb http://dl.google.com/linux/chrome/deb/ stable main' >> /etc/apt/sources.list.d/google-chrome.list  && curl -s https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -  && apt-get update -qq  && apt-get install -y --no-install-recommends build-essential libpq-dev nodejs google-chrome-stable chromedriver  && apt-get clean  && rm -rf /var/cache/apt/archives/* /var/lib/apt/lists/*' returned a non-zero code: 100
```