### PR TITLE
Fix failing specs like following due to chrome settings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,8 +62,20 @@ RSpec.configure do |config|
 end
 
 Capybara.register_driver :selenium_chrome_headless do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome, desired_capabilities: Selenium::WebDriver::Remote::Capabilities.chrome(chrome_options: { args: %w(headless disable-infobars disable-extensions disable-gpu no-sandbox disable-setuid-sandbox window-size=1024,1024) }))
+  browser_options = Selenium::WebDriver::Chrome::Options.new
+  browser_options.args << '--headless'
+  browser_options.args << '--disable-gpu'
+  browser_options.args << '--no-sandbox'
+
+  Capybara::Selenium::Driver.new(
+    app, browser: :chrome, options: browser_options
+  ).tap do |driver|
+    driver.browser.manage.window.size = Selenium::WebDriver::Dimension.new(
+      1920, 1080
+    )
+  end
 end
+
 Capybara.javascript_driver = :selenium_chrome_headless
 Capybara.raise_server_errors = false
 


### PR DESCRIPTION
```
Failure/Error: visit "/"

Selenium::WebDriver::Error::UnknownError:
  unknown error: Chrome failed to start: exited abnormally.
    (unknown error: DevToolsActivePort file doesn't exist)
    (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```